### PR TITLE
[setup.py] added missing dependency Pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='python-geotiepoints',
       url="https://github.com/adybbroe/python-geotiepoints",
       download_url="https://github.com/adybbroe/python-geotiepoints/tarball/v0.1.0#egg=python-geotiepoints-v0.1.0",
       packages = ['geotiepoints'],      
-      install_requires=['numpy', 'scipy', 'pyresample'],
+      install_requires=['numpy', 'scipy', 'pyresample', 'pandas'],
       zip_safe = False
       )
 


### PR DESCRIPTION
`basic_interpolator` imports pandas, which was not in the `install_requires`
this commit adds `pandas` to the `install_requires` in setup.py
